### PR TITLE
[WIP] Add slide number usage on save, update slides dimensions values…

### DIFF
--- a/Demos/MVC/src/Products/Editor/Entity/Web/Request/EditDocumentRequest.cs
+++ b/Demos/MVC/src/Products/Editor/Entity/Web/Request/EditDocumentRequest.cs
@@ -15,6 +15,9 @@ namespace GroupDocs.Editor.MVC.Products.Editor.Entity.Web.Request
         [JsonProperty]
         private String password;
 
+        [JsonProperty]
+        private int pageNumber;
+
         public String getContent()
         {
             return content;
@@ -33,6 +36,16 @@ namespace GroupDocs.Editor.MVC.Products.Editor.Entity.Web.Request
         public void setPassword(String password)
         {
             this.password = password;
+        }
+
+        public int getPageNumber()
+        {
+            return pageNumber;
+        }
+
+        public void setPageNumber(int pageNumber)
+        {
+            this.pageNumber = pageNumber;
         }
     }
 }


### PR DESCRIPTION
Code changes for this PR were copied and merged from following PR: https://github.com/groupdocs-editor/GroupDocs.Editor-for-.NET-MVC/pull/17.

**Problem:**
We would like to be able to edit content of the specific presentation slide.

**Solution:**
1. Was added handling the page number parameter passed from UI.
2. Additionally was added other way for setting slides dimensions.

Related PR: https://github.com/groupdocs-total/GroupDocs.Total-Angular/pull/207.